### PR TITLE
Transfer links to chemreps org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # chemreps
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation Status](https://readthedocs.org/projects/chemreps/badge/?version=latest)](https://chemreps.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/dlf57/chemreps/branch/master/graph/badge.svg)](https://codecov.io/gh/dlf57/chemreps)
-[![Build Status](https://travis-ci.com/dlf57/chemreps.svg?branch=master)](https://travis-ci.com/dlf57/chemreps)
+[![codecov](https://codecov.io/gh/chemreps/chemreps/branch/master/graph/badge.svg)](https://codecov.io/gh/chemreps/chemreps)
+[![Build Status](https://travis-ci.com/chemreps/chemreps.svg?branch=master)](https://travis-ci.com/chemreps/chemreps)
+[![Gitter Chat](https://img.shields.io/gitter/room/chemreps/community.svg)](https://gitter.im/chemreps/community)
 
 chemreps is a Python package for the creation of molecular representations for the purpose of machine learning. The molecular representations included in this library are implemented/adapted from current literature. The aim of chemreps is to provide an easy to use library for making molecular representations that can be then used with machine learning packages such as Scikit-Learn and Tensorflow.
 
@@ -25,7 +26,7 @@ pip install chemreps
 
 The latest development version can be installed by:
 ```
-git clone https://github.com/dlf57/chemreps
+git clone https://github.com/chemreps/chemreps
 cd chemreps
 pip install -e .
 ```
@@ -37,10 +38,13 @@ chemreps requires:
 - cclib (>=1.5)
 
 ## Contributing
-If you are interested in helping develop for this project, please check out [Contributing to chemreps](https://github.com/dlf57/chemreps/wiki/Contributing-to-chemreps) in the wiki for a guide on how to get started.
+If you are interested in helping develop for this project, please check out [Contributing to chemreps](https://github.com/chemreps/chemreps/wiki/Contributing-to-chemreps) in the wiki for a guide on how to get started.
 
 ## Testing
 Tests can be run in the top-level directory with the command `pytest -v --cov=chemreps tests/`
+
+## For help
+If you need any help using chemreps, feel free to post in our [Gitter](https://gitter.im/chemreps/community).
 
 ## Disclaimers:
 - These are attempts at the recreation of molecular representations from literature and may not be implemented properly.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def setup_chemreps():
         version='0.0.4',
         packages=['chemreps', 'chemreps.utils'],
         license='MIT License',
-        url='https://github.com/dlf57/chemreps',
+        url='https://github.com/chemreps/chemreps',
         description='Molecular machine learning representations',
         long_description=open('README.md').read(),
         install_requires=[


### PR DESCRIPTION
Hopefully, this is all we need to fix in order to have everything transferred to chemreps org