### PR TITLE
ImportWarning aborts when we would just want to run

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,3 @@
 exclude_lines =
     atomi, atomj = atomj, atomi
     a, c = c, a
-    if rdkit_loader is None:

--- a/chemreps/__init__.py
+++ b/chemreps/__init__.py
@@ -13,4 +13,4 @@ rdkit_loader = importlib.util.find_spec('rdkit')
 if rdkit_loader is not None:
     from . import fingerprints
 elif rdkit_loader is None: 
-    raise ImportWarning('RDKit was not found. As a result, the Morgan fingerprint representation module has not been imported.')
+    print('RDKit was not found. As a result, the Morgan fingerprint representation module has not been imported.')

--- a/tests/optional_dependency_test.py
+++ b/tests/optional_dependency_test.py
@@ -1,46 +1,12 @@
 from unittest import mock
 import pytest
 import warnings
-import builtins
 import importlib
-import sys
 
-#@pytest.fixture
-#def hide_available_rdkit(monkeypatch):
-#    import_orig = builtins.__import__
-#    def mocked_import(name, *args, **kwargs):
-#        if name == 'rdkit':
-#            raise ImportError()
-#        return import_orig(name, *args, **kwargs)
-#    
-#
-#    def mocked_spec(name, *args, **kwargs):
-#        print(name)
-#        if name == 'rdkit':
-#            return None
-#        return sys.modules[name].__spec__
-#
-#    monkeypatch.setattr(builtins, '__import__', mocked_import)
-#    monkeypatch.setattr(builtins, '__spec__', mocked_spec)
-
-#@pytest.mark.usefixtures('hide_available_rdkit')
 def test_warning_raised_if_rdkit_not_installed():
-    #https://stackoverflow.com/questions/60746184/test-behavior-of-code-if-optional-module-is-not-installed
-    #import sys
-
-    # clear cached modules
-    #mods = list(sys.modules.keys())
-    #if 'rdkit' in mods:
-    #     del sys.modules['rdkit']
-    #with warnings.catch_warnings(record=True) as w:
     with pytest.warns(UserWarning):
         patcher = mock.patch('importlib.util.find_spec')
         importlib_find_spec_mock = patcher.start()
         importlib_find_spec_mock.return_value = None
         import chemreps
         importlib.reload(chemreps)
-        #print(w)
-        #assert len(w) > 0
-        #assert issubclass(w[-1].category, UserWarning)
-        #assert "RDKit was not found. As a result, the Morgan fingerprint representation module has not been imported." == str(w[-1].message)
-    #del sys.modules['rdkit']

--- a/tests/optional_dependency_test.py
+++ b/tests/optional_dependency_test.py
@@ -10,12 +10,13 @@ def test_warning_raised_if_rdkit_not_installed():
     # clear cached modules
     mods = list(sys.modules.keys())
     for mod in mods:
-        if 'chemreps' in mod or 'RDkit' in mod:
+        if 'chemreps' in mod or 'rdkit' in mod:
             del sys.modules[mod]
 
-    sys.modules['RDkit'] = mock.MagicMock()
+    sys.modules['rdkit'] = mock.MagicMock()
     with warnings.catch_warnings(record=True) as w:
         import chemreps
+        assert len(w) > 0
         assert issubclass(w[-1].category, UserWarning)
         assert "RDKit was not found. As a result, the Morgan fingerprint representation module has not been imported." == str(w[-1].message)
-    del sys.modules['RDkit']
+    del sys.modules['rdkit']

--- a/tests/optional_dependency_test.py
+++ b/tests/optional_dependency_test.py
@@ -3,17 +3,27 @@ import pytest
 import warnings
 import builtins
 import importlib
+import sys
 
-@pytest.fixture
-def hide_available_rdkit(monkeypatch):
-    import_orig = builtins.__import__
-    def mocked_import(name, *args, **kwargs):
-        if name == 'rdkit':
-            raise ImportError()
-        return import_orig(name, *args, **kwargs)
-    monkeypatch.setattr(builtins, '__import__', mocked_import)
+#@pytest.fixture
+#def hide_available_rdkit(monkeypatch):
+#    import_orig = builtins.__import__
+#    def mocked_import(name, *args, **kwargs):
+#        if name == 'rdkit':
+#            raise ImportError()
+#        return import_orig(name, *args, **kwargs)
+#    
+#
+#    def mocked_spec(name, *args, **kwargs):
+#        print(name)
+#        if name == 'rdkit':
+#            return None
+#        return sys.modules[name].__spec__
+#
+#    monkeypatch.setattr(builtins, '__import__', mocked_import)
+#    monkeypatch.setattr(builtins, '__spec__', mocked_spec)
 
-@pytest.mark.usefixtures('hide_available_rdkit')
+#@pytest.mark.usefixtures('hide_available_rdkit')
 def test_warning_raised_if_rdkit_not_installed():
     #https://stackoverflow.com/questions/60746184/test-behavior-of-code-if-optional-module-is-not-installed
     #import sys
@@ -22,9 +32,11 @@ def test_warning_raised_if_rdkit_not_installed():
     #mods = list(sys.modules.keys())
     #if 'rdkit' in mods:
     #     del sys.modules['rdkit']
-    #sys.modules['rdkit'] = mock.MagicMock()
     #with warnings.catch_warnings(record=True) as w:
     with pytest.warns(UserWarning):
+        patcher = mock.patch('importlib.util.find_spec')
+        importlib_find_spec_mock = patcher.start()
+        importlib_find_spec_mock.return_value = None
         import chemreps
         importlib.reload(chemreps)
         #print(w)

--- a/tests/optional_dependency_test.py
+++ b/tests/optional_dependency_test.py
@@ -1,22 +1,34 @@
 from unittest import mock
 import pytest
 import warnings
+import builtins
+import importlib
 
+@pytest.fixture
+def hide_available_rdkit(monkeypatch):
+    import_orig = builtins.__import__
+    def mocked_import(name, *args, **kwargs):
+        if name == 'rdkit':
+            raise ImportError()
+        return import_orig(name, *args, **kwargs)
+    monkeypatch.setattr(builtins, '__import__', mocked_import)
 
+@pytest.mark.usefixtures('hide_available_rdkit')
 def test_warning_raised_if_rdkit_not_installed():
     #https://stackoverflow.com/questions/60746184/test-behavior-of-code-if-optional-module-is-not-installed
-    import sys
+    #import sys
 
     # clear cached modules
-    mods = list(sys.modules.keys())
-    for mod in mods:
-        if 'chemreps' in mod or 'rdkit' in mod:
-            del sys.modules[mod]
-
-    sys.modules['rdkit'] = mock.MagicMock()
-    with warnings.catch_warnings(record=True) as w:
+    #mods = list(sys.modules.keys())
+    #if 'rdkit' in mods:
+    #     del sys.modules['rdkit']
+    #sys.modules['rdkit'] = mock.MagicMock()
+    #with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(UserWarning):
         import chemreps
-        assert len(w) > 0
-        assert issubclass(w[-1].category, UserWarning)
-        assert "RDKit was not found. As a result, the Morgan fingerprint representation module has not been imported." == str(w[-1].message)
-    del sys.modules['rdkit']
+        importlib.reload(chemreps)
+        #print(w)
+        #assert len(w) > 0
+        #assert issubclass(w[-1].category, UserWarning)
+        #assert "RDKit was not found. As a result, the Morgan fingerprint representation module has not been imported." == str(w[-1].message)
+    #del sys.modules['rdkit']

--- a/tests/optional_dependency_test.py
+++ b/tests/optional_dependency_test.py
@@ -1,0 +1,21 @@
+from unittest import mock
+import pytest
+import warnings
+
+
+def test_warning_raised_if_rdkit_not_installed():
+    #https://stackoverflow.com/questions/60746184/test-behavior-of-code-if-optional-module-is-not-installed
+    import sys
+
+    # clear cached modules
+    mods = list(sys.modules.keys())
+    for mod in mods:
+        if 'chemreps' in mod or 'RDkit' in mod:
+            del sys.modules[mod]
+
+    sys.modules['RDkit'] = mock.MagicMock()
+    with warnings.catch_warnings(record=True) as w:
+        import chemreps
+        assert issubclass(w[-1].category, UserWarning)
+        assert "RDKit was not found. As a result, the Morgan fingerprint representation module has not been imported." == str(w[-1].message)
+    del sys.modules['RDkit']


### PR DESCRIPTION
For example, if we want to use things besides fingerprints:
```
import chemreps
import numpy as np

from chemreps import utils

a = np.array([0,0,1])
b = np.array([0,0,0])
c = np.array([0,1,0])

print(chemreps.utils.calcs.ang(a,b,c)/((np.pi)/(180.0)))

print("OK")
```
we can't because an import warning is raised:
```
ImportWarning: RDKit was not found. As a result, the Morgan fingerprint representation module has not been imported.
```

I think for now we should leave this as a print statement.
